### PR TITLE
add index.js to file path if module path refer to a folder

### DIFF
--- a/lib/replacer.js
+++ b/lib/replacer.js
@@ -14,6 +14,13 @@ function Replacer(options) {
 	this.path = options.path;
 	this.refs = [];
 
+	if ( !fs.existsSync(this.path)  ) {
+		var newName = this.path.replace(/\.js$/,'/index.js');
+		if (fs.existsSync(newName)){
+			this.path = newName;
+		}
+	}
+	
 	var pipeline = this.map.transform.reduce(function (stream, transform) {
 		return stream.pipe(transform(options.path));
 	}, fs.createReadStream(this.path, {encoding: 'utf-8'}));


### PR DESCRIPTION
pure-cjs failed to find modules under module_dir/index.js
if required as require('module_dir')
