### PR TITLE
add index.js to file path if module path refer to a folder

### DIFF
--- a/lib/replacer.js
+++ b/lib/replacer.js
@@ -1,4 +1,5 @@
 var Promise = require('./promise'),
+	fs = require('fs'),
 	pathUtils = require('./pathUtils'),
 	isCoreModule = require('resolve').isCore,
 	astTypes = require('ast-types'),
@@ -11,6 +12,15 @@ function Replacer(options) {
 	this.map = options.map;
 	this.path = options.path;
 	this.refs = [];
+	
+	// if this.path does not exists, chech to see if it is a folder,
+	// and then check if path/index.js exists. If it exists, load it
+	if ( !fs.existsSync(this.path)  ) {
+		var newName = this.path.replace(/\.js$/,'/index.js');
+		if (fs.existsSync(newName)){
+			this.path = newName;
+		}
+	}
 
 	if (options.externalId) {
 		this.promise = Promise.resolve([b.returnStatement(options.externalId)]);


### PR DESCRIPTION
cjs specify that if a folder is required and it contains a file named index.js, it has to be loaded.
pure-cjs give an error instead.
