### PR TITLE
Problem with global external dependency

### DIFF
--- a/lib/pathUtils.js
+++ b/lib/pathUtils.js
@@ -27,3 +27,22 @@ exports.getNodePath = function (from, to, options) {
 exports.ext = function (path) {
 	return stdUtils.extname(path).slice(1).toLowerCase();
 };
+
+//
+// path for external dependencies
+// I'm not sure if this is working by coincidence
+exports.getNodePathExternal = function (from, to, options) {
+
+	var fromDir = from;
+	var opts = {
+		basedir: stdUtils.resolve('', fromDir),
+		extensions: (options.defaultExt !== 'js' ? ['.' + options.defaultExt] : []).concat(['.js', '.json']),
+		moduleDirectory: options.moduleDir
+	};
+
+
+	var resolved = nodeResolve.sync(to, opts);
+
+	return exports.normalizePath(resolved);
+
+};

--- a/lib/replacer.js
+++ b/lib/replacer.js
@@ -12,7 +12,21 @@ function Replacer(options) {
 	this.refs = [];
 
 	if (options.externalId) {
-		this.promise = Promise.resolve([b.returnStatement(options.externalId)]);
+		// global external dependency should be assigned
+		// to module.exports.
+		// maybe this not work for amd?
+		this.promise = Promise.resolve(
+			[
+			b.expressionStatement(
+				b.assignmentExpression(
+					'=',
+					b.memberExpression(
+						b.identifier('module'),
+						b.identifier('exports'),
+						false 
+					),
+					options.externalId
+			))]);
 	} else {
 		this.promise = this.map.getFileAST({
 			source: this.path,

--- a/lib/replacerMap.js
+++ b/lib/replacerMap.js
@@ -3,23 +3,32 @@ var Promise = require('./promise'),
 	pathUtils = require('./pathUtils');
 
 function ReplacerMap(options) {
+
 	this.replacers = {};
 	this.promises = [];
 	this.getFileAST = options.getFileAST;
 	this.comments = options.comments;
 	this.defaultExt = options.defaultExt;
 	this.moduleDir = options.moduleDir;
+	
 	this.depsMap = options.deps.reduce(function (obj, dep) {
-		obj[pathUtils.getNodePath('_', dep.name, this)] = dep;
+		if (!dep.global && !dep.amd) {
+			var path = pathUtils.getNodePath('_', dep.name, this);
+			obj[path] = dep;	
+		} else {
+			// use different path for external dependencies?
+			obj[pathUtils.getNodePathExternal('_', dep.name, this)] = dep;	
+		}
+		
 		return obj;
 	}.bind(this), {});
+	
 }
 
 ReplacerMap.prototype.get = function (path) {
 	if (path in this.replacers) {
 		return this.replacers[path];
 	}
-
 	var id = this.promises.length++,
 		replacer = this.replacers[path] = new Replacer({
 			map: this,


### PR DESCRIPTION
I'm trying to use global external dependency via external option.
I got two problem:

1) modules declared as external could not be found by node_resolve, and it throws an exception. I solved this adding `exports.getNodePathExternal` in pathUtils.js. This solve my problem, but I doubt that could be by accident (I think an external module should not be  passed to node_resolve at all, but I was not able to find a way)

2) ast generated for global external module was rendered as

``` javascript
function (module, exports) {
     return __external_modulename;
},
```

while the correct code is:

``` javascript
function (module, exports) {
     module.exports = __external_modulename;
},
```

But please confirm that this change doesn't break amd external...
