### PR TITLE
Support any string as module identifier, not just valid JS prop names

### DIFF
--- a/lib/templates/umdWrapper.js
+++ b/lib/templates/umdWrapper.js
@@ -16,7 +16,7 @@ var undef = b.identifier('undefined');
         }) %);
     } else {
         // Browser globals
-        this.<%= b.identifier(exports) %> = factory(%= deps.map(function (dep) {
+        this[<%= b.literal(exports) %>] = factory(%= deps.map(function (dep) {
             return dep.global ? b.identifier(dep.global) : undef;
         }) %);
   }

--- a/test/suites/a (exports A with externals)/expected.js
+++ b/test/suites/a (exports A with externals)/expected.js
@@ -12,7 +12,7 @@
         module.exports = factory(require('davy'), require('url'));
     } else {
         // Browser globals
-        this.A = factory(davy, undefined);
+        this['A'] = factory(davy, undefined);
     }
 }(function (__external_davy, __external_url) {
     var global = this, define;

--- a/test/suites/a (exports A with map and comments)/expected.js
+++ b/test/suites/a (exports A with map and comments)/expected.js
@@ -9,7 +9,7 @@
         module.exports = factory(require('url'));
     } else {
         // Browser globals
-        this.A = factory(undefined);
+        this['A'] = factory(undefined);
     }
 }(function (__external_url) {
     var global = this, define;

--- a/test/suites/a (exports A with map)/expected.js
+++ b/test/suites/a (exports A with map)/expected.js
@@ -4,7 +4,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('url'));
     } else {
-        this.A = factory(undefined);
+        this['A'] = factory(undefined);
     }
 }(function (__external_url) {
     var global = this, define;

--- a/test/suites/a (exports A)/expected.js
+++ b/test/suites/a (exports A)/expected.js
@@ -4,7 +4,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('url'));
     } else {
-        this.A = factory(undefined);
+        this['A'] = factory(undefined);
     }
 }(function (__external_url) {
     var global = this, define;


### PR DESCRIPTION
Fixes: https://github.com/RReverser/pure-cjs/issues/20